### PR TITLE
Add: support custom grpc.DialOption through CreateHandlerWithDialOpts

### DIFF
--- a/client.go
+++ b/client.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	channelzgrpc "google.golang.org/grpc/channelz/grpc_channelz_v1"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 func (h *grpcChannelzHandler) connect() (channelzgrpc.ChannelzClient, error) {
@@ -19,7 +18,7 @@ func (h *grpcChannelzHandler) connect() (channelzgrpc.ChannelzClient, error) {
 	host := getHostFromBindAddress(h.bindAddress)
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	client, err := newChannelzClient(host)
+	client, err := newChannelzClient(host, h.dialOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -27,10 +26,8 @@ func (h *grpcChannelzHandler) connect() (channelzgrpc.ChannelzClient, error) {
 	return h.client, nil
 }
 
-func newChannelzClient(dialString string) (channelzgrpc.ChannelzClient, error) {
-	conn, err := grpc.Dial(dialString,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
+func newChannelzClient(dialString string, opts ...grpc.DialOption) (channelzgrpc.ChannelzClient, error) {
+	conn, err := grpc.Dial(dialString, opts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error dialing to %s", dialString)
 	}

--- a/handler.go
+++ b/handler.go
@@ -5,20 +5,53 @@ import (
 	"path"
 	"sync"
 
+	"google.golang.org/grpc"
 	channelzgrpc "google.golang.org/grpc/channelz/grpc_channelz_v1"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 // CreateHandler creates an http handler with the routes of channelz mounted to the provided prefix.
 // pathPrefix is the prefix to which /channelz will be prepended
 // grpcBindAddress is the TCP bind address for the gRPC service you'd like to monitor.
-// 	grpcBindAddress is required since the channelz interface connects to this gRPC service
-//
+// grpcBindAddress is required since the channelz interface connects to this gRPC service.
 // Typically you'd use the return value of CreateHandler as an argument to http.Handle
 // For example:
-// 	http.Handle("/", channelz.CreateHandler("/foo", grpcBindAddress))
+//
+// http.Handle("/", channelz.CreateHandler("/foo", grpcBindAddress))
+//
+// grpc.Dial is called using grpc.WithTransportCredentials(insecure.NewCredentials()).
+// If you need custom DialOptions like credentials, TLS or interceptors, please
+// refer to CreateHandlerWithDialOpts().
 func CreateHandler(pathPrefix, grpcBindAddress string) http.Handler {
+	return CreateHandlerWithDialOpts(
+		pathPrefix,
+		grpcBindAddress,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+}
+
+// CreateHandlerWithDialOpts is the same as CreateHandler but with custom []grpc.DialOption
+// You need to provide all grpc.DialOption to be used for the internal call to grpc.Dial().
+// This typically includes some form of grpc.WithTransportCredentials().
+// Here's an example on how to use a bufconn instead of a real TCP listener:
+// lis := bufconn.Listen(1024 * 1024)
+// grpcserver.Serve(lis)
+// http.Handle("/", channelzWeb.CreateHandlerWithDialOpts("/", "",
+//
+//	[]grpc.DialOption{
+//		grpc.WithTransportCredentials(insecure.NewCredentials()),
+//		grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+//			return lis.DialContext(ctx)
+//		}),
+//	}...,
+//
+// ))
+func CreateHandlerWithDialOpts(pathPrefix, grpcBindAddress string, dialOpts ...grpc.DialOption) http.Handler {
 	prefix := path.Join(pathPrefix, "channelz") + "/"
-	handler := &grpcChannelzHandler{bindAddress: grpcBindAddress}
+	handler := &grpcChannelzHandler{
+		bindAddress: grpcBindAddress,
+		dialOpts:    dialOpts,
+	}
 	return createRouter(prefix, handler)
 }
 
@@ -28,6 +61,9 @@ type grpcChannelzHandler struct {
 
 	// The client connection (lazily initialized)
 	client channelzgrpc.ChannelzClient
+
+	// []grpc.DialOption to use for grpc.Dial
+	dialOpts []grpc.DialOption
 
 	mu sync.Mutex
 }


### PR DESCRIPTION
This adds support for using custom []grpc.DialOption in the call to grpc.Dial() through the use of CreateHandlerWithDialOpts.

Behaviour of CreateHandler() is unchanged.

By doing so, one can implement TLS as requested in #9 or as in my case use in memory listeners instead of binding to TCP addresses.

All tests and builds are running fine. Please review and merge if possible. 